### PR TITLE
List active clusters

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -13,16 +13,7 @@ if ! openstack security group show '8a1289c1-0584-453a-935c-9a3df67aef32' > /dev
     exit
 fi
 
-VALID_LIMIT=$(date --date='-5 hours' +%s)
-
-for network in $(openstack network list -c Name -f value); do
-    if [[ $network == *-*-openshift ]]; then
-        CREATION_TIME=$(openstack network show $network -c created_at -f value)
-        CREATION_TIMESTAMP=$(date --date="$CREATION_TIME" +%s)
-        if [[ $CREATION_TIMESTAMP < $VALID_LIMIT ]]; then
-            CLUSTER_ID=${network/-openshift/}
-            echo Destroying $CLUSTER_ID
-            time ./destroy_cluster.sh -i $CLUSTER_ID
-        fi
-    fi
+for cluster_id in $(./list-clusters -ls); do
+	echo Destroying "$cluster_id"
+	time ./destroy_cluster.sh -i "$cluster_id"
 done

--- a/list-clusters
+++ b/list-clusters
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+unrecognised_command() {
+	echo "Unrecognised command: $*"
+	exit 1
+}
+
+print_help() {
+	echo 'https://github.com/shiftstack/shiftstack-ci'
+	echo
+	echo 'list-clusters [ -a | -s ] [ -l ]'
+	echo
+	echo 'Prints the IDs of the detected clusters, based on their Network.'
+	echo
+	echo -e '\t-a only lists active clusters'
+	echo -e '\t-s only lists stale clusters'
+	echo
+	echo -e '\t-l prints the full cluster name. Otherwise, truncates at 14 characters'
+	echo
+	echo 'Clusters are identified as stale if their network is more than 5 hours old.'
+}
+
+print_cluster_id() {
+	declare \
+		cluster_id="$1" \
+		format="$2"
+
+	case "$format" in
+		'long' ) echo "$cluster_id" ;;
+		'short') echo "${cluster_id:0:14}" ;;
+		*  ) >&2 echo "wrong format '$format'" ; exit 1 ;;
+	esac
+}
+
+VALID_LIMIT="$(date --date='-5 hours' +%s)"
+readonly VALID_LIMIT
+
+declare filter=''
+declare format='short'
+
+while getopts lash o; do
+	case "$o" in
+		l) format='long'             ;;
+		a) filter='active'           ;;
+		s) filter='stale'            ;;
+		h) print_help; exit          ;;
+		*) unrecognised_command "$@" ;;
+	esac
+done
+
+for network in $(openstack network list -c Name -f value); do
+	if [[ $network = *-*-openshift ]]; then
+		CLUSTER_ID="${network/-openshift/}"
+		case "$filter" in
+			'active')
+				CREATION_TIME=$(openstack network show "$network" -c created_at -f value)
+				CREATION_TIMESTAMP=$(date --date="$CREATION_TIME" +%s)
+				if [[ "$CREATION_TIMESTAMP" -ge "$VALID_LIMIT" ]]; then
+					print_cluster_id "$CLUSTER_ID" "$format"
+				fi
+				;;
+			'stale')
+				CREATION_TIME=$(openstack network show "$network" -c created_at -f value)
+				CREATION_TIMESTAMP=$(date --date="$CREATION_TIME" +%s)
+				if [[ "$CREATION_TIMESTAMP" -lt "$VALID_LIMIT" ]]; then
+					print_cluster_id "$CLUSTER_ID" "$format"
+				fi
+				;;
+			*)
+				print_cluster_id "$CLUSTER_ID" "$format"
+				;;
+		esac
+	fi
+done


### PR DESCRIPTION
Add a new `list-clusters` command that can print a list of the active
clusters.

It is useful for listing stale resources:

```
openstack server list -f value -c ID -c Name | grep -vf <(./list-clusters -a)
```