### PR TITLE
Fail if can't reach the cluster

### DIFF
--- a/refresh_rhcos.sh
+++ b/refresh_rhcos.sh
@@ -45,7 +45,10 @@ IMAGE_SHA="$(jq --raw-output '.images.openstack."uncompressed-sha256"' "$RHCOS_V
 IMAGE_URL="$(jq --raw-output '.baseURI + .images.openstack.path' "$RHCOS_VERSIONS_FILE")"
 IMAGE_VERSION="$(jq --raw-output '."ostree-version"' "$RHCOS_VERSIONS_FILE")"
 
-if openstack image show -c properties -f json "$IMAGE_NAME" | grep -q "$IMAGE_VERSION"; then
+current_image_version="$(mktemp)"
+openstack image show -c properties -f json "$IMAGE_NAME" > "$current_image_version"
+
+if grep -q "$IMAGE_VERSION" "$current_image_version"; then
     echo "RHCOS image '${IMAGE_NAME}' already at the latest version '$IMAGE_VERSION'"
     exit
 fi


### PR DESCRIPTION
Before this patch, an error in reaching the cluster was interpreted as a
grep failure.

By separating the call to openstack-cli from the call to grep, the
script now exits if openstack fails.