### PR TITLE
destroy_cluster -f to remove the server group

### DIFF
--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -80,6 +80,7 @@ if [[ $FORCE == true ]]; then
     openstack security group delete $INFRA_ID-master
     openstack security group delete $INFRA_ID-worker
 
+    openstack server group delete $INFRA_ID-master
 
     for c in $(openstack container list -f value); do
         echo $c


### PR DESCRIPTION
`destroy_cluster.sh -fi xxx-xxx-xxx` comes handy for deleting image-registry data when installer-driven cluster deletion is stuck with undeletable resources.