### PR TITLE
Delete leftover containers from CI tenant

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -37,3 +37,8 @@ for cluster_id in $(./list-clusters -ls); do
 		time ./destroy_cluster.sh -i "$cluster_id"
 	fi
 done
+
+# Clean leftover containers
+openstack container list -f value -c Name |\
+        grep -vf <(./list-clusters -a) |\
+        xargs --no-run-if-empty openstack container delete -r


### PR DESCRIPTION
There's a bunch of old containers in the CI tenant, some empty, some
having ~500MB of files.

Let's delete the ones with no associated active cluster. I'm
intentionally checking for the router rather than for the network
because of name consistency between UPI and IPI.