### PR TITLE
List stale resources

### DIFF
--- a/stale
+++ b/stale
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+unknown_command() {
+	echo "Unknown command: $*"
+	exit 1
+}
+
+print_help() {
+	echo 'https://github.com/shiftstack/shiftstack-ci/stale'
+	echo
+	echo 'Prints the IDs of the stale resources, with the timestamp of the last update and the resource name.'
+	echo
+	echo 'Usage:'
+	echo "$0 [-un|-q] <resource_type>"
+	echo
+	echo '"resource_type" can be any openstack resource type.'
+	echo 'Resources are identified as stale if they were last updated more than 5 hours ago.'
+	echo
+	echo -u  Only print the ID and the timestamp of the last update
+	echo -n  Only print the ID and the resource name
+	echo -q  Only print the ID
+	echo
+	echo 'Examples:'
+	echo "$0 port"
+	echo "$0 -q floating ip"
+}
+
+declare \
+	print_name=no \
+	print_updated=no \
+	quiet=no
+while getopts nuqh o; do
+	case "$o" in
+		n) print_name=yes       ;;
+		u) print_updated=yes    ;;
+		q) quiet=yes            ;;
+		h) print_help; exit     ;;
+		*) unknown_command "$@" ;;
+	esac
+done
+if [[ $print_name == 'yes' ]] || [[ $print_updated == 'yes' ]]; then
+	if [[ $quiet == 'yes' ]]; then
+		>&2 echo '-q can not be used with -n or -u.'
+		exit 2
+	fi
+else
+	if [[ $quiet != 'yes' ]]; then
+		print_name=yes
+		print_updated=yes
+	fi
+fi
+shift $((OPTIND - 1))
+
+declare -r resource_type="$*"
+
+declare valid_limit
+valid_limit="$(date --date='-5 hours' +%s)"
+readonly valid_limit
+
+list_server() {
+	for resource_id in $(openstack server list -f value -c ID); do
+		res="$(openstack server show -f json -c updated -c name "$resource_id")"
+		update_time="$(jq -r '.updated' <<< "$res")"
+		name="$(jq -r '.name' <<< "$res")"
+		printf '%s %s %s\n' "$resource_id" "$update_time" "$name"
+	done
+}
+
+list_port() {
+	openstack port list -f json -c ID -c Name -c 'Updated At' \
+		| jq -r '.[] | "\(.ID) \(."Updated At") \(.Name)"'
+}
+
+list_generic() {
+	declare rt="$1"
+	for resource_id in $(openstack "$rt" list -f value -c ID); do
+		res="$(openstack "$rt" show -f json -c updated_at -c name "$resource_id")"
+		update_time="$(jq -r '.updated_at' <<< "$res")"
+		name="$(jq -r '.name' <<< "$res")"
+		printf '%s %s %s\n' "$resource_id" "$update_time" "$name"
+	done
+}
+
+case $resource_type in
+	server)
+		list_server ;;
+	port)
+		list_port ;;
+	'network'|'network trunk'|'subnet'|'floating ip'|'security group'|'volume')
+		list_generic "$resource_type" ;;
+	'server group')
+		>&2 printf 'Creation date is not available for %s.' "$resource_type"
+		exit 3
+		;;
+	*)
+		>&2 printf 'Resource "%s" not implemented.' "$resource_type"
+		exit 3
+		;;
+esac | while read -r resource_id update_time name; do
+	if [[ "$(date --date="$update_time" +%s)" -lt "$valid_limit" ]]; then
+		printf '%s' "$resource_id"
+		if [[ $print_updated == 'yes' ]]; then
+			printf ' %s' "$update_time"
+		fi
+		if [[ $print_name == 'yes' ]]; then
+			printf ' %s' "$name"
+		fi
+		printf '\n'
+	fi
+done


### PR DESCRIPTION
List resources that were last updated more than 5 hours ago.

Usage:
```shell
./stale port
./stale -nu floating ip
```

* `-u`  Also prints the timestamp of the last update
* `-n`  Also prints the resource name

Implemented for:
* server
* port
* network
* network trunk
* subnet
* floating ip
* security group