### PR TITLE
Do not add "hyperthreading: Enabled" for machine sets

### DIFF
--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -77,15 +77,13 @@ apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
 clusterID:  ${CLUSTER_ID}
 compute:
-- hyperthreading: Enabled
-  name: worker
+- name: worker
   platform:
     openstack:
       type: ${OPENSTACK_WORKER_FLAVOR}
       ${WORKER_ROOT_VOLUME}
   replicas: ${WORKER_COUNT}
 controlPlane:
-  hyperthreading: Enabled
   name: master
   platform:
     openstack:


### PR DESCRIPTION
This parameter is enabled by default anyway, so there is no reason to set it in the install config.
https://github.com/openshift/installer/blob/master/data/data/install.openshift.io_installconfigs.yaml#L46