### PR TITLE
Save cluster artifacts in its own directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # ignore other user's cluster configs
 *cluster_config.sh
 
+# ignore cluster artifacts
+/clusters

--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -13,6 +13,8 @@ if [ ! -r "$CONFIG" ]; then
 fi
 source ./${CONFIG}
 
+ARTIFACT_DIR=clusters/${CLUSTER_NAME}
+
 opts=$(getopt -n "$0"  -o "fi:" --long "force,infra-id:"  -- "$@")
 
 eval set --$opts
@@ -48,9 +50,9 @@ fi
 
 if [[ $FORCE == true ]]; then
     echo Destroying cluster using openstack cli
-    if [ -z "$INFRA_ID" ] && [ -f $CLUSTER_NAME/metadata.json ]; then
+    if [ -z "$INFRA_ID" ] && [ -f $ARTIFACT_DIR/metadata.json ]; then
         # elements created by the cluster are named $CLUSTER_NAME-hash by the installer
-        INFRA_ID=$(jq .infraID $CLUSTER_NAME/metadata.json | sed "s/\"//g")
+        INFRA_ID=$(jq .infraID $ARTIFACT_DIR/metadata.json | sed "s/\"//g")
     fi
 
     if [ -z "$INFRA_ID" ]; then
@@ -101,7 +103,7 @@ if [[ $FORCE == true ]]; then
     fi
 else
     echo Destroying cluster using openshift-install
-    "$installer" --log-level=debug destroy cluster --dir ${TMP_DIR:-$CLUSTER_NAME}
+    "$installer" --log-level=debug destroy cluster --dir ${TMP_DIR:-$ARTIFACT_DIR}
 fi
 
 if [ ! -z "$TMP_DIR" ]; then

--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -51,8 +51,10 @@ if [ "${ssh_config}" != "${old_ssh_config}" ]; then
   echo "$ssh_config" >>  $HOME/.ssh/config
 fi
 
-if [ ! -d $CLUSTER_NAME ]; then
-    mkdir -p $CLUSTER_NAME
+ARTIFACT_DIR=clusters/${CLUSTER_NAME}
+
+if [ ! -d ${ARTIFACT_DIR} ]; then
+    mkdir -p ${ARTIFACT_DIR}
 fi
 
 : "${OPENSTACK_WORKER_FLAVOR:=${OPENSTACK_FLAVOR}}"
@@ -70,9 +72,9 @@ if [[ ${OPENSTACK_WORKER_VOLUME_TYPE} != "" ]]; then
         type: ${OPENSTACK_WORKER_VOLUME_TYPE}"
 fi
 
-if [ ! -f $CLUSTER_NAME/install-config.yaml ]; then
+if [ ! -f ${ARTIFACT_DIR}/install-config.yaml ]; then
     export CLUSTER_ID=$(uuidgen --random)
-    cat > $CLUSTER_NAME/install-config.yaml << EOF
+    cat > ${ARTIFACT_DIR}/install-config.yaml << EOF
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
 clusterID:  ${CLUSTER_ID}
@@ -114,7 +116,7 @@ sshKey: |
 EOF
 fi
 
-"$installer" --log-level=debug ${1:-create} ${2:-cluster} --dir $CLUSTER_NAME
+"$installer" --log-level=debug ${1:-create} ${2:-cluster} --dir ${ARTIFACT_DIR}
 
 # Attaching FIP to ingress port to access the cluster from outside
 # check whether we have a free floating IP

--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -53,9 +53,8 @@ fi
 
 ARTIFACT_DIR=clusters/${CLUSTER_NAME}
 
-if [ ! -d ${ARTIFACT_DIR} ]; then
-    mkdir -p ${ARTIFACT_DIR}
-fi
+rm -rf ${ARTIFACT_DIR}
+mkdir -p ${ARTIFACT_DIR}
 
 : "${OPENSTACK_WORKER_FLAVOR:=${OPENSTACK_FLAVOR}}"
 


### PR DESCRIPTION
The cluster artifacts are now all saved in a `clusters` directory to
stop polluting the root of the repository.

Also delete existing artifact directory when re-running the install script.