### PR TITLE
Make builders/build_capo.sh working out of the box

### DIFF
--- a/builders/build_capo.sh
+++ b/builders/build_capo.sh
@@ -19,6 +19,8 @@ help() {
 : ${TAG:="capo"}
 : ${RELEASE:="4.7"}
 : ${OC_REGISTRY_AUTH_FILE:="config.json"}
+: ${OPENSTACK_RELEASE:="train"}
+: ${CAPO_DIR:=""}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -66,14 +68,30 @@ if [ ! -f "$OC_REGISTRY_AUTH_FILE" ]; then
 fi
 
 DEST_IMAGE="quay.io/$USERNAME/origin-release:$TAG"
-FROM_IMAGE="registry.svc.ci.openshift.org/ocp/release:$RELEASE"
+FROM_IMAGE="registry.svc.ci.openshift.org/origin/release:$RELEASE"
 CAPO_IMAGE="quay.io/$USERNAME/capo:$TAG"
 
 echo "Start building CAPO image $CAPO_IMAGE"
 
-go get sigs.k8s.io/cluster-api-provider-openstack
-pushd $GOPATH/src/sigs.k8s.io/cluster-api-provider-openstack
-podman build --no-cache -t $CAPO_IMAGE .
+if [ -z "$CAPO_DIR" ]; then
+    # Go returns an error like "no Go files" but the repo is actually cloned.
+    go get github.com/openshift/cluster-api-provider-openstack || true
+    CAPO_DIR=$GOPATH/src/github.com/openshift/cluster-api-provider-openstack
+else
+    if [ ! -d "$CAPO_DIR" ]; then
+        echo "$CAPO_DIR does not exist, exiting ..."
+        exit 1
+    fi
+    echo "$CAPO_DIR will be used to build CAPO"
+fi
+
+pushd $CAPO_DIR
+REPOS_DIR=$(mktemp -d -t build-origin-XXXXXXXXXX)
+curl https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_repos/ocp-$RELEASE-default.repo -o $REPOS_DIR/ocp-$RELEASE-default.repo
+curl https://github.com/openshift/shared-secrets/blob/master/mirror/ops-mirror.pem -o $REPOS_DIR/ops-mirror.pem
+curl https://raw.githubusercontent.com/openshift/installer/master/images/openstack/rdo-$OPENSTACK_RELEASE.repo -o $REPOS_DIR/openstack.repo
+podman build --no-cache -v $REPOS_DIR:/etc/yum.repos.d/:z -v $REPOS_DIR/ops-mirror.pem:/tmp/key/ops-mirror.pem:z -t $CAPO_IMAGE .
+rm -rf $REPOS_DIR
 podman push $CAPO_IMAGE
 popd
 
@@ -84,17 +102,17 @@ echo "Start building local release image"
 oc adm release new \
     --registry-config="$OC_REGISTRY_AUTH_FILE" \
     --from-release="$FROM_IMAGE" \
-    --to-file="origin-release.tar" \
     --server https://api.ci.openshift.org \
-    -n openshift \
+    --to-image $DEST_IMAGE \
     openstack-machine-controllers=$CAPO_IMAGE
 
-echo "Local release image is saved to $PWD/origin-release.tar"
-
-podman import origin-release.tar $DEST_IMAGE
-
-podman push $DEST_IMAGE
-
-rm -f origin-release.tar
-
 echo "Successfully pushed $DEST_IMAGE"
+
+echo "Testing release image"
+podman pull $DEST_IMAGE
+if ! podman run --rm $DEST_IMAGE image openstack-machine-controllers >/dev/null; then
+    echo "$DEST_IMAGE is not usable, something went wrong, exiting ..."
+    exit 1
+fi
+echo "$DEST_IMAGE image was tested, you can now deploy with the following command:"
+echo "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$DEST_IMAGE openshift-install create cluster (...)"


### PR DESCRIPTION
This will help to build openshift/capo without complication.

You just need a valid auth file and that's it.
If you want to specify a directory for CAPO, use $CAPO_DIR and it won't
clone it.

Also it adds some validation at the end to make sure that the release
image is usable for an actual deployment.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
