### PR TITLE
Start using new registry for image builders

### DIFF
--- a/builders/README.md
+++ b/builders/README.md
@@ -1,18 +1,15 @@
 # How to get credentials
 
-It's critical to correctly configure the credentials
-here or the building process will fail with permission
-errors.
+It's critical to correctly configure the credentials here or the building process will fail with permission errors.
 
-For registry.ci.openshift.org, you first need to
-copy the token from https://api.ci.openshift.org/console/catalog
-(top right, "Copy Login Command") and run this command:
+For registry.ci.openshift.org, you first need to copy the token from https://oauth-openshift.apps.ci.l2s4.p1.openshiftapps.com/oauth/token/request (top left, "Display Token") and run this command:
+
+```sh
 podman login --authfile <authfile> -u <username> -p <token> https://registry.ci.openshift.org
-The right credentials should be updated in the authfile,
-that will be used to build the images later.
+```
 
+The right credentials should be updated in the authfile, that will be used to build the images later.
 
-For quay.io, the credentials that need to be taken
-are from:
-https://cloud.redhat.com/openshift/install/openstack/installer-provisioned
-Do not use your personal credentials, they won't work.
+For quay.io, the credentials that need to be taken are from https://cloud.redhat.com/openshift/install/openstack/installer-provisioned
+
+**NOTE:** Do not use your personal credentials, they won't work.

--- a/builders/README.md
+++ b/builders/README.md
@@ -4,10 +4,10 @@ It's critical to correctly configure the credentials
 here or the building process will fail with permission
 errors.
 
-For registry.svc.ci.openshift.org, you first need to
+For registry.ci.openshift.org, you first need to
 copy the token from https://api.ci.openshift.org/console/catalog
 (top right, "Copy Login Command") and run this command:
-podman login --authfile <authfile> -u <username> -p <token> https://registry.svc.ci.openshift.org
+podman login --authfile <authfile> -u <username> -p <token> https://registry.ci.openshift.org
 The right credentials should be updated in the authfile,
 that will be used to build the images later.
 

--- a/builders/build_capo.sh
+++ b/builders/build_capo.sh
@@ -68,7 +68,7 @@ if [ ! -f "$OC_REGISTRY_AUTH_FILE" ]; then
 fi
 
 DEST_IMAGE="quay.io/$USERNAME/origin-release:$TAG"
-FROM_IMAGE="registry.svc.ci.openshift.org/origin/release:$RELEASE"
+FROM_IMAGE="registry.ci.openshift.org/origin/release:$RELEASE"
 CAPO_IMAGE="quay.io/$USERNAME/capo:$TAG"
 
 echo "Start building CAPO image $CAPO_IMAGE"

--- a/builders/build_mco.sh
+++ b/builders/build_mco.sh
@@ -30,7 +30,7 @@ fi
 USERNAME="$1"
 
 DEST_IMAGE="quay.io/$USERNAME/origin-release:$TAG"
-FROM_IMAGE="registry.svc.ci.openshift.org/origin/release:4.2"
+FROM_IMAGE="registry.ci.openshift.org/origin/release:4.2"
 MCO_IMAGE=quay.io/$USERNAME/machine-config-operator:$TAG
 
 pushd $GOPATH/src/github.com/openshift/machine-config-operator

--- a/builders/config.json.example
+++ b/builders/config.json.example
@@ -1,6 +1,6 @@
 {
 	"auths": {
-		"registry.svc.ci.openshift.org": {
+		"registry.ci.openshift.org": {
 			"auth": "<data>"
 		},
 		"quay.io": {


### PR DESCRIPTION
registry.svc.ci.openshift.org has been deprecated, and we have to start using registry.ci.openshift.org
Allso we need to update the documentation on how to get credentials for the new registry.