### PR TITLE
report: Slack out, Prometheus in

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -45,9 +45,9 @@ report() {
 		if [ "$json" = true ]; then
 			result=$(jq ".\"$resource_type\" += [\"$resource_id\"]" "$resultfile")
 		else
-			result="$(cat $resultfile - <<< "$resource_type $resource_id")"
+			result="$(printf '%s\t%s' "$resource_type" "$resource_id" | cat "$resultfile" - )"
 		fi
-		cat > $resultfile <<< "$result"
+		cat > "$resultfile" <<< "$result"
 		echo "$resource_id"
 	done
 }


### PR DESCRIPTION
Remove Slack as a reporting tool.

Report instead in the Open Metrics format, for Prometheus to parse.
Further reporting and alerting can be built on Prometheus.

a prerequisite for shiftstack-bot automation.