### PR TITLE
clean-ci-credentials: shiftstack-bot automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # ignore cluster artifacts
 /clusters
+
+# ignore cloud credentials
+/bot/cloud-credentials.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+KEY_NAME ?= $(shell whoami)
+
+shiftstack-bot: bot/cloud-credentials.json
+	ansible-playbook -i bot/inventory.yaml bot/clean-ci-resources.yaml
+.PHONY: shiftstack-bot
+
+bot/cloud-credentials.json:
+	bot/openstack-credentials.sh vexxhost moc-ci moc psi > $@
+
+server:
+	OS_CLOUD=psi ./server.sh -f ci.m1.micro -i Fedora-Cloud-Base-33 -e provider_net_shared_3 -k $(KEY_NAME) -p shiftstack-bot
+.PHONY: server

--- a/bot/clean-ci-resources.yaml
+++ b/bot/clean-ci-resources.yaml
@@ -1,0 +1,100 @@
+---
+
+- hosts: all
+
+  vars_files:
+  - cloud-credentials.json
+
+  tasks:
+  - name: 'Install system packages'
+    become: yes
+    dnf:
+      name:
+      - git
+      - jq
+      - python-openstackclient
+      - caddy
+      state: latest
+
+  - name: 'Add the clean-ci-resources user'
+    become: yes
+    user:
+      name: clean-ci-resources
+
+  - name: 'Add the clean-ci-resources metrics directory'
+    become: yes
+    file:
+      name: /var/clean-ci-resources
+      state: directory
+      owner: clean-ci-resources
+      group: caddy
+      mode: g+r
+
+  - name: 'Add an openstack config directory'
+    become: yes
+    become_user: clean-ci-resources
+    file:
+      name: /home/clean-ci-resources/.config/openstack
+      state: directory
+
+  - name: 'Add clouds.yaml'
+    become: yes
+    become_user: clean-ci-resources
+    template:
+      src: templates/clouds.yaml.j2
+      dest: /home/clean-ci-resources/.config/openstack/clouds.yaml
+
+  - name: 'Add secure.yaml'
+    become: yes
+    become_user: clean-ci-resources
+    template:
+      src: templates/secure.yaml.j2
+      dest: /home/clean-ci-resources/.config/openstack/secure.yaml
+
+  - name: 'Install openshift-install'
+    become: yes
+    unarchive:
+      remote_src: yes
+      src: '{{ openshift_install_src }}'
+      dest: /usr/bin/
+      exclude:
+      - README.md
+
+  - name: 'Clone shiftstack-ci'
+    become: yes
+    become_user: clean-ci-resources
+    git:
+      repo: 'https://github.com/shiftstack/shiftstack-ci.git'
+      dest: /home/clean-ci-resources/shiftstack-ci
+
+  - name: 'Add metrics webserver config'
+    become: yes
+    template:
+      src: templates/Caddyfile.j2
+      dest: /etc/caddy/Caddyfile
+
+  - name: 'Create the systemd service for clean-ci-resources '
+    become: yes
+    template:
+      src: templates/clean-ci-resources.service.j2
+      dest: /lib/systemd/system/clean-ci-resources.service
+
+  - name: 'Create the systemd timer for clean-ci-resources '
+    become: yes
+    template:
+      src: templates/clean-ci-resources.timer.j2
+      dest: /lib/systemd/system/clean-ci-resources.timer
+
+  - name: 'Enable the clean-ci-resources timer'
+    become: yes
+    systemd:
+      name: clean-ci-resources.timer
+      enabled: yes
+      state: started
+
+  - name: 'Enable the metrics webserver'
+    become: yes
+    systemd:
+      name: caddy.service
+      enabled: yes
+      state: started

--- a/bot/inventory.yaml
+++ b/bot/inventory.yaml
@@ -1,0 +1,12 @@
+---
+
+all:
+  hosts:
+    shiftstack-bot:
+      ansible_python_interpreter: "{{ansible_playbook_python}}"
+
+      ci_clean_log_cloud: 'psi'
+      ci_clean_log_container: 'shiftstack-bot'
+      ci_clean_timer_oncalendar: 'hourly'
+
+      openshift_install_src: 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.8/openshift-install-linux.tar.gz'

--- a/bot/openstack-credentials.sh
+++ b/bot/openstack-credentials.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+# * Creates application credentials for all clouds in the available clouds.yaml
+# * Outputs them in the format consumable by the Ansible playbook:
+#    { "clouds": [{ "name": "<cloud name>", "auth_url": "", "credential_id": "", "credential_secret": ""}]}
+for cloud in "$@"; do
+	openstack --os-cloud "$cloud" application credential create shiftstack-bot -f json -c id -c secret \
+		| jq '{"credential_id": .id, "credential_secret": .secret} + {"name": "'"$cloud"'"}' \
+		| jq '.+{"auth_url": "'"$(openstack --os-cloud "$cloud" catalog show identity -f json | jq -r '.endpoints[] | select(.interface=="public").url + "/v3"')"'"}'
+done | jq -sc '. | {"clouds": .}'

--- a/bot/templates/Caddyfile.j2
+++ b/bot/templates/Caddyfile.j2
@@ -1,0 +1,4 @@
+http://localhost:9097 {
+    root * /var/clean-ci-resources
+    file_server
+}

--- a/bot/templates/clean-ci-resources.service.j2
+++ b/bot/templates/clean-ci-resources.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=clean-ci-resources
+
+[Service]
+User=clean-ci-resources
+Environment=log_cloud={{ ci_clean_log_cloud }}
+Environment=log_container={{ ci_clean_log_container }}
+Environment=metrics_file=/var/clean-ci-resources/metrics
+WorkingDirectory=/home/clean-ci-resources/shiftstack-ci
+ExecStart=/usr/bin/env bash /home/clean-ci-resources/shiftstack-ci/report.sh -c "$log_cloud" -o "$log_container" -m "$metrics_file" moc-ci vexxhost

--- a/bot/templates/clean-ci-resources.timer.j2
+++ b/bot/templates/clean-ci-resources.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=clean-ci-resources timer
+
+[Timer]
+Unit=clean-ci-resources.service
+OnCalendar={{ ci_clean_timer_oncalendar }}
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/bot/templates/clouds.yaml.j2
+++ b/bot/templates/clouds.yaml.j2
@@ -1,0 +1,8 @@
+clouds:
+{% for cloud in clouds %}
+
+  {{ cloud.name }}:
+    auth:
+      auth_url: '{{ cloud.auth_url }}'
+    identity_api_version: 3
+{% endfor %}

--- a/bot/templates/secure.yaml.j2
+++ b/bot/templates/secure.yaml.j2
@@ -1,0 +1,9 @@
+clouds:
+{% for cloud in clouds %}
+
+  {{ cloud.name }}:
+    auth:
+      application_credential_id: '{{ cloud.credential_id }}'
+      application_credential_secret: '{{ cloud.credential_secret }}'
+    auth_type: "v3applicationcredential"
+{% endfor %}

--- a/server.sh
+++ b/server.sh
@@ -119,6 +119,7 @@ sg_id="$(openstack security group create -f value -c id "$name")"
 >&2 echo "Created security group ${sg_id}"
 openstack security group rule create --ingress --protocol tcp  --dst-port 22 --description "${name} SSH" "$sg_id" >/dev/null
 openstack security group rule create --ingress --protocol icmp               --description "${name} ingress ping" "$sg_id" >/dev/null
+openstack security group rule create --ingress --protocol tcp  --dst-port 80 --description "${name} ingress HTTP" "$sg_id" >/dev/null
 >&2 echo 'Security group rules created.'
 
 network_id="$(openstack network create -f value -c id "$name")"


### PR DESCRIPTION
* Creates application credentials
* Creates a server in OpenStack and uploads the application credentials
  to it
* Installs systemd services and timers to run the cleanup
* Exposes the cleanup results to localhost:9097 in the Open Metrics
  format
