### PR TITLE
Include clean up of Kuryr Cloud

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -13,6 +13,9 @@ case "$(openstack security group show -f value -c id default)" in
 	1e7008c1-10f4-4d09-9d6e-d3de70b62eb6)
 		>&2 echo 'Operating on VEXXHOST'
 		;;
+	25b7cd46-495e-4862-a4a8-2222af553092)
+		>&2 echo 'Operating on Kuryr Cloud'
+		;;
 	*)
 		>&2 echo "Refusing to run on anything else than the CI tenant"
 		exit 1

--- a/list-clusters
+++ b/list-clusters
@@ -51,7 +51,7 @@ while getopts lash o; do
 done
 
 for network in $(openstack network list -c Name -f value); do
-	if [[ $network = *-*-openshift ]] || [[ $network = *-*-network ]]; then
+	if [[ $network = *-*-openshift ]] || [[ $network = *-*-network ]] && [[ $network != *"kuryr"* ]]; then
 		declare CLUSTER_ID="$network"
 
 		# IPI


### PR DESCRIPTION
This commit includes the clean up of leftovers in
the Kuryr Cloud. Also, it makes sure to keep retriving
the clusterID only from the Nodes Network.