### PR TITLE
Remove reference to ocp-doit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 This repository contains tools to help build and simplify a testing environment
 for the development of OpenShift 4.x installation against an OpenStack cloud.
 
-It is complementary to
-[ocp-doit](https://github.com/shiftstack-dev-tools/ocp-doit) that focus on
-deploying OCP using a standalone TripleO.
-
 ## Prerequisites
 
 Access to an OpenStack cloud fitting the [OpenShift on OpenStack


### PR DESCRIPTION
It is obsolete because it does not work with the the
current HAProxy/CoreDNS architecture.

Signed-off-by: Tom Barron <tpb@dyncloud.net>