### PR TITLE
clean-ci-resources: force the deletion of all resources

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -48,7 +48,7 @@ report() {
 }
 
 for cluster_id in $(./list-clusters -ls); do
-	time ./destroy_cluster.sh -i "$(echo "$cluster_id" | report cluster)"
+	time ./destroy_cluster.sh -f -i "$(echo "$cluster_id" | report cluster)"
 done
 
 # Clean leftover containers


### PR DESCRIPTION
It seems like that some CI jobs are not deprovisining clusters well
enough, leaving unused ports and therefore impossible to remove the
cluster later.

This patch is a mitigation until we figure it out on the
installer/destroy code how these staled ports could be removed, before
we try to remove security groups and other resources like
networks/subnets.

Example of CI error:
```
level=debug msg=Deleting Security Group "97b3d153-e85f-4bdb-8a0e-c95a89233d72" failed with error: Expected HTTP response code [] when accessing [DELETE https://openstack/v2.0/security-groups/97b3d153-e85f-4bdb-8a0e-c95a89233d72], but got 409 instead
level=debug msg={"NeutronError": {"type": "SecurityGroupInUse", "message": "Security Group 97b3d153-e85f-4bdb-8a0e-c95a89233d72 in use.", "detail": ""}}
```

This is a log from a cluster destroy.

Running the destroy_cluster script with -f, will manually remove these
ports for now.
