### PR TITLE
Don't clean default SGs

### DIFF
--- a/stale
+++ b/stale
@@ -73,6 +73,18 @@ list_port() {
 		| jq -r '.[] | "\(.ID) \(."Updated At") \(.Name)"'
 }
 
+list_security_group() {
+	for resource_id in $(openstack security group list -f value -c ID); do
+		res="$(openstack security group show -f json -c updated_at -c name "$resource_id")"
+		update_time="$(jq -r '.updated_at' <<< "$res")"
+		name="$(jq -r '.name' <<< "$res")"
+		# we can't and don't want to remove the default security group
+		if [ "$name" != "default" ]; then
+			printf '%s %s %s\n' "$resource_id" "$update_time" "$name"
+		fi
+	done
+}
+
 list_generic() {
 	declare rt="$1"
 	for resource_id in $(openstack "$rt" list -f value -c ID); do
@@ -88,8 +100,10 @@ case $resource_type in
 		list_server ;;
 	port)
 		list_port ;;
-	'network'|'network trunk'|'subnet'|'floating ip'|'security group'|'volume'|'volume snapshot')
+	'network'|'network trunk'|'subnet'|'floating ip'|'volume'|'volume snapshot')
 		list_generic "$resource_type" ;;
+	'security group')
+		list_security_group ;;
 	'server group')
 		>&2 printf 'Creation date is not available for %s.' "$resource_type"
 		exit 3


### PR DESCRIPTION
It avoids messages like:


```
Failed to delete group with name or ID '1e7008c1-10f4-4d09-9d6e-d3de70b62eb6': ConflictException: 409: Client Error for url: https://network.rdo.mtl2.vexxhost.net/v2.0/security-groups/1e7008c1-10f4-4d09-9d6e-d3de70b62eb6, Insufficient rights for removing default security group.

```