### PR TITLE
clean-ci: add keypair to resources to clean

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -57,7 +57,7 @@ openstack container list -f value -c Name \
 	| report container \
 	| xargs --verbose --no-run-if-empty openstack container delete -r
 
-for resource in 'volume snapshot' 'volume' 'floating ip' 'security group'; do
+for resource in 'volume snapshot' 'volume' 'floating ip' 'security group' 'keypair'; do
 	if [[ ${resource} == 'volume' ]]; then
 	  for r in $(./stale -q "$resource"); do
 	    status=$(openstack "${resource}" show -c status -f value "${r}")

--- a/stale
+++ b/stale
@@ -105,6 +105,15 @@ list_generic() {
 	done
 }
 
+list_keypair() {
+	for resource_id in $(openstack keypair list -f value -c Name); do
+		res="$(openstack keypair show -f json -c created_at -c Name "$resource_id")"
+		update_time="$(jq -r '.created_at' <<< "$res")"
+		name="$(jq -r '.name' <<< "$res")"
+		printf '%s %s %s\n' "$resource_id" "$update_time" "$name"
+	done
+}
+
 case $resource_type in
 	server)
 		list_server ;;
@@ -116,6 +125,8 @@ case $resource_type in
 		list_loadbalancer ;;
 	'security group')
 		list_security_group ;;
+	'keypair')
+		list_keypair ;;
 	'server group')
 		>&2 printf 'Creation date is not available for %s.' "$resource_type"
 		exit 3


### PR DESCRIPTION
This was tested against `mecha` and it cleans staled keypairs.
