### PR TITLE
Retry destroying cluster with --force if it failed gracefully

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -47,8 +47,15 @@ report() {
 	done
 }
 
-for cluster_id in $(./list-clusters -ls); do
+leftover_clusters=$(./list-clusters -ls)
+
+for cluster_id in $leftover_clusters; do
 	time ./destroy_cluster.sh -i "$(echo "$cluster_id" | report cluster)"
+done
+
+# Try again, this time via openstack commands directly
+for cluster_id in $leftover_clusters; do
+	time ./destroy_cluster.sh --force -i "$(echo "$cluster_id" | report cluster)"
 done
 
 # Clean leftover containers


### PR DESCRIPTION
Just to make sure we nuke letfover resources from our CI tenants.