### PR TITLE
metrics.sh: Add timestamp

### DIFF
--- a/metrics.sh
+++ b/metrics.sh
@@ -12,8 +12,9 @@ os_project="$(openstack token issue -f value -c project_id)"
 
 echo "# These metrics refer to project '$os_project' in the '$OS_CLOUD' cloud."
 for service in 'compute' 'network'; do
+	timestamp="$(date +"%s000")"
 	openstack quota list --detail "--${service}" --project "$os_project" -f value -c 'Resource' -c 'In Use' -c 'Limit' \
 		| sed -n \
-			-e 's/^\(\w\+\)\s\([[:digit:]]\+\)\s\([[:digit:]]\+\)$/'"$service"'_\1{quota="inuse"} \2\n'"$service"'_\1{quota="limit"} \3/gp;' \
-			-e 's/^\(\w\+\)\s\([[:digit:]]\+\)\s-1$/'"$service"'_\1{quota="inuse"} \2/gp'
+			-e 's/^\(\w\+\)\s\([[:digit:]]\+\)\s\([[:digit:]]\+\)$/'"$service"'_\1{quota="inuse"} \2 '"$timestamp"'\n'"$service"'_\1{quota="limit"} \3 '"$timestamp"'/gp;' \
+			-e 's/^\(\w\+\)\s\([[:digit:]]\+\)\s-1$/'"$service"'_\1{quota="inuse"} \2 '"$timestamp"'/gp'
 done


### PR DESCRIPTION
Given that the collection will be performed by Prow with an frequency in
the order of minutes, a timestamp will help solving aliasing problems
when building the time series on the Prometheus side.