### PR TITLE
borderline: fix when limit is set to 0

### DIFF
--- a/borderline.sh
+++ b/borderline.sh
@@ -40,6 +40,10 @@ check_quotas() {
         metric_inuse=$(echo "$line" | awk '{ print $2 }')
         metric_reserved=$(echo "$line" | awk '{ print $3 }')
         metric_limit=$(echo "$line" | awk '{ print $4 }')
+        if [[ "$metric_limit" -eq 0 ]]; then
+            echo "  No quotas set for ${metric_name}"
+            continue
+        fi
         if [[ "$metric_limit" -eq -1 ]]; then
             echo "  Unlimited quotas for ${metric_name}"
             continue


### PR DESCRIPTION
When a limit is set to 0, it just means there is no quota for that
resource, and we can't create any; so we can skip it and go to the next
resource.

It'll avoid this type of error:
```
./borderline.sh: line 48: ((: percentage_value=0*100/0: division by 0 (error token is "0")
```
