### PR TITLE
borderline.sh: Signal low quota

### DIFF
--- a/borderline.sh
+++ b/borderline.sh
@@ -67,7 +67,7 @@ check_quotas network
 
 if [[ "$failed" -eq 1 ]]; then
     echo "Some resources have less than ${min_percentage}% available, actions should be taken!"
-    exit 1
+    exit 11
 fi
 
 echo "No issue found, all resources have at least ${min_percentage}% of the total available"


### PR DESCRIPTION
Prior to this patch, borderline.sh returned 1 when low quota was
detected, making it difficult to distinguish the outcome from a crash.

With this patch, borderline.sh returns with code 11 when low quota is
detected.