### PR TITLE
server: few changes for SSH

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -219,7 +219,7 @@ openstack floating ip set --port "$lb_vip_id" "$fip_id"
 
 if [ "$os_user" != '' ]; then
 	echo "Testing connectivity from the instance ${name}"
-	if ! ssh "$os_user"@"$fip_address" ping -c 1 1.1.1.1; then
+	if ! ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no "$os_user"@"$fip_address" ping -c 1 1.1.1.1; then
 		echo "Error when running a ping from the instance..."
 		exit 1
 	fi


### PR DESCRIPTION
## SSH timeout
When creating a server and assigning a floating IP to the port, it can
take a few seconds before we can actually SSH.

Let's have a timeout of 30s.

## Disable host verification
Host verification can be disabled in the context of CI, this makes it
easy to use in ephemeral environments.