### PR TITLE
server: add a sleep before SSH'ing the VM

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -204,6 +204,7 @@ openstack floating ip set --port "$lb_vip_id" "$fip_id"
 
 if [ "$os_user" != '' ]; then
 	echo "Testing connectivity from the instance ${name}"
+	sleep 20
 	if ! ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no "$os_user"@"$fip_address" ping -c 1 1.1.1.1; then
 		echo "Error when running a ping from the instance..."
 		exit 1


### PR DESCRIPTION
It might take a bit of time so the VM is fully started and SSH being
available.
Adding a sleep will reduce the change to hit connection errors.
