### PR TITLE
Containerfile: hack to have more reliable builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,14 @@
 FROM registry.fedoraproject.org/fedora:34
 
-RUN dnf update -y \
-	&& dnf install -y \
+COPY ./ ./
+
+RUN ./hack/dnf_safe update -y \
+	&& ./hack/dnf_safe install -y \
 		ShellCheck \
 		make \
+		python3-openstackclient \
+		python3-octaviaclient \
+		jq \
 	&& dnf clean all
 
 WORKDIR /src
-
-COPY ./ ./

--- a/hack/dnf_safe
+++ b/hack/dnf_safe
@@ -1,0 +1,54 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#
+# This script will run any DNF command and stop until the command returns 0
+# Usage:
+# ./dnf_safe install python3-openstackclient -y
+# This will attempts to intall openstackclient, until it works, up to 10 attempts
+# and a break of 5 seconds between retries.
+#
+
+set -eu
+DEBUG=${DEBUG:-}
+if [ -n "$DEBUG" ]; then
+    set -x
+fi
+
+# Function to run a command with a retry.
+# You can specify the number of total retries in $1
+# and the sleep time (in seconds) between retries.
+function retry {
+    local retries=$1
+    local time=$2
+    shift 2
+
+    local count=0
+    until "$@"; do
+      exit=$?
+      count=$(($count + 1))
+      if [ $count -lt $retries ]; then
+        echo "Failed to run 'dnf' after $count attempts, will retry in $time..."
+        sleep $time
+      else
+        return $exit
+      fi
+    done
+    return 0
+}
+
+retry 10 5 sudo dnf "$@"


### PR DESCRIPTION
Fedora repos are not reliable, and very often we have issues when
building the images, where the repo is not available, under heavy use
and therefore can't serve the packages that we need.

This is problematic as it's causing some of our CI jobs to fail, and
creating a lot of noise.

To address this issue, we propose to implement an hack to safely run
DNF with retries (up to 10 retries when a failure is hit, with 5s of
break between attempts).

This patch also adds python3-openstackclient & python3-octaviaclient
& jq which are needed by our CI job running shiftstack-ci specific
jobs.
