### PR TITLE
Fix getting FIP when multiple matches

### DIFF
--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -16,8 +16,7 @@ set -x
 declare -r installer="${OPENSHIFT_INSTALLER:-$GOPATH/src/github.com/openshift/installer/bin/openshift-install}"
 
 # check whether we have a free floating IP
-FLOATING_IP=$(openstack floating ip list --status DOWN --network "$OPENSTACK_EXTERNAL_NETWORK" --long --format value -c "Floating IP Address" -c Description | grep "${CLUSTER_NAME}" | sed 's/ .*//g')
-FLOATING_IP=$(echo "$FLOATING_IP" | cut -d ' ' -f1)
+FLOATING_IP=$(openstack floating ip list --status DOWN --network "$OPENSTACK_EXTERNAL_NETWORK" --long --format value -c "Floating IP Address" -c Description | grep "${CLUSTER_NAME}-api" | head -n 1 | sed 's/ .*//g' | cut -d ' ' -f1)
 
 # create new floating ip if doesn't exist
 if [ -z "$FLOATING_IP" ]; then


### PR DESCRIPTION
When multiple FIPs matched the search criteria, the script would take
all of then and insert them in the install-config.yaml as following:

    platform:
      openstack:
        [...]
        lbFloatingIP:     128.31.26.47
    128.31.26.253

This later caused the installer to fail with:

    FATAL failed to fetch Metadata: failed to load asset "Install Config": failed to unmarshal install-config.yaml: error converting YAML to JSON: yaml: line 36: could not find expected ':'

This patch selects the first FIP matching the search criteria.