### PR TITLE
Containerfile: Fix working directory

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,5 @@
 FROM registry.fedoraproject.org/fedora:34
 
-COPY ./ ./
-
 RUN ./hack/dnf_safe update -y \
 	&& ./hack/dnf_safe install -y \
 		ShellCheck \
@@ -12,3 +10,5 @@ RUN ./hack/dnf_safe update -y \
 	&& dnf clean all
 
 WORKDIR /src
+
+COPY ./ ./


### PR DESCRIPTION
With this change, we do not rely any more on the base image to set the
target directory for COPY. This Containerfile relies on the fact that
the working directory is exactly the directory where files are copied
to.