### PR TITLE
cleanup: Refuse to run unless forced

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -27,6 +27,7 @@ done
 
 if [ $DELETE != 1 ]; then
 	echo "Refusing to run unless passing the --delete-everything-older-than-5-hours option"
+	exit 5
 fi
 
 cat > "$resultfile" <<< '{}'


### PR DESCRIPTION
The `--delete-everything-older-than-5-hours` option was not respected
prior to this patch.