### PR TITLE
Remove clusterID from install-config.yaml

### DIFF
--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -76,12 +76,9 @@ if [[ ${OPENSTACK_WORKER_VOLUME_TYPE} != "" ]]; then
 fi
 
 if [ ! -f "${ARTIFACT_DIR}"/install-config.yaml ]; then
-    CLUSTER_ID=$(uuidgen --random)
-    export CLUSTER_ID
     cat > "${ARTIFACT_DIR}"/install-config.yaml << EOF
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
-clusterID:  ${CLUSTER_ID}
 compute:
 - name: worker
   platform:


### PR DESCRIPTION
It looks like it has never been a valid attribute in
install-config.yaml. Recent change in OCP 4.10 now validate the
install-config.yaml and errors out on unknown attributes. We should then
drop it.