### PR TITLE
destroy_cluster.sh relative path in CONFIG

### DIFF
--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -8,7 +8,7 @@
 CONFIG=${CONFIG:-cluster_config.sh}
 if [ -r "$CONFIG" ]; then
   # shellcheck disable=SC1090
-  source ./"${CONFIG}"
+  source "${CONFIG}"
 fi
 
 ARTIFACT_DIR=clusters/${CLUSTER_NAME}


### PR DESCRIPTION
The CONFIG environment variable as sourced in destroy_cluster.sh uses a
relative path prefix of ./ which causes issues when you specify a full
path to the script. Changing to not use relative path results in the
execution matching that of run_ocp.sh.

Co-Authored-By: Emma Foley <efoley@redhat.com>
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
