### PR TITLE
destroy_cluster: run cluster destroy with a timeout

### DIFF
--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -106,7 +106,10 @@ if [[ $FORCE == true ]]; then
     fi
 else
     echo Destroying cluster using openshift-install
-    "$installer" --log-level=debug destroy cluster --dir "${TMP_DIR:-$ARTIFACT_DIR}"
+    timeout 900 "$installer" --log-level=debug destroy cluster --dir "${TMP_DIR:-$ARTIFACT_DIR}"
+    if [ $? -eq "124" ]; then
+        echo "Timeout to destroy cluster after 15 min"
+    fi
 fi
 
 if [ -n "$TMP_DIR" ]; then


### PR DESCRIPTION
This script is run in our CI and the job currently timeouts if
`openshift-install destroy` never manage to finish (it's the case when a
resource is not destroyed). So let's run the destroy command during 15
minutes and if it didn't finish on time, report it in the logs but move
on.
Later, we have code that will force the deletion of these ressources.
