### PR TITLE
clean-ci-resources: clean LB resources in ACTIVE state

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -100,7 +100,7 @@ for resource in 'loadbalancer' 'server' 'router' 'subnet' 'network' 'volume snap
 		  for r in $(./stale.sh -q "$resource"); do
 			status=$(openstack "${resource}" show -c provisioning_status -f value "${r}")
 			case "$status" in
-				ERROR)
+				ACTIVE|ERROR)
 					# shellcheck disable=SC2086
 					echo "$r" | report $resource | xargs --verbose openstack $resource delete --cascade
 					;;


### PR DESCRIPTION
Add the `ACTIVE` state in the case statement. If a LB is ACTIVE or in
ERROR, it can be cleaned up.