### PR TITLE
build_mco: allow to override release

### DIFF
--- a/builders/build_mco.sh
+++ b/builders/build_mco.sh
@@ -6,21 +6,28 @@ help() {
     echo "Usage: ./build_mco.sh [options] <quay.io username>"
     echo "Options:"
     echo "-h, --help      show this message"
+    echo "-r, --release   openshift release version, default: 4.11"
     echo "-t, --tag       push to a custom tag in your origin release image repo, default: mco"
     echo ""
 }
 
 TAG="mco"
 
+: "${RELEASE:="4.11"}"
+
 # Parse Options
 case $1 in
     -h|--help)
         help
         exit 0;;
+    -r|--release)
+        RELEASE=$2
+        shift 2
+        ;;
     -t|--tag)
         TAG=$2
-        shift
-        shift;;
+        shift 2
+        ;;
     *);;
 esac
 
@@ -32,7 +39,7 @@ fi
 USERNAME="$1"
 
 DEST_IMAGE="quay.io/$USERNAME/origin-release:$TAG"
-FROM_IMAGE="registry.ci.openshift.org/origin/release:4.2"
+FROM_IMAGE="registry.ci.openshift.org/origin/release:$RELEASE"
 MCO_IMAGE=quay.io/$USERNAME/machine-config-operator:$TAG
 
 pushd "$GOPATH"/src/github.com/openshift/machine-config-operator || exit
@@ -41,6 +48,7 @@ podman push "$MCO_IMAGE"
 
 oc adm release new \
     --from-release="$FROM_IMAGE" \
+    --include=rhel-coreos-8 rhel-coreos-8=registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest \
     --to-image="$DEST_IMAGE" \
     --server https://api.ci.openshift.org \
     -n openshift \


### PR DESCRIPTION
* Add `--release` argument so we can now override the release (default
  to 4.11).
* Include `rhel-coreos-8` image when building the release image, it's
  now required for MCO, at least on 4.12.
