### PR TITLE
Dump console on liveliness check failure

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -246,7 +246,7 @@ for driver in "${!drivers[@]}"; do
 
 	if [ "$os_user" != '' ]; then
 		echo "Testing connectivity from the instance ${name}"
-		sleep 20
+		sleep 60
 		if ! ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no "$os_user"@"$fip_address" ping -c 1 1.1.1.1; then
 			echo "Error when running a ping from the instance. Dumping instance console..."
 			openstack console log show "$name" || true

--- a/server.sh
+++ b/server.sh
@@ -248,7 +248,9 @@ for driver in "${!drivers[@]}"; do
 		echo "Testing connectivity from the instance ${name}"
 		sleep 20
 		if ! ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no "$os_user"@"$fip_address" ping -c 1 1.1.1.1; then
-			echo "Error when running a ping from the instance..."
+			echo "Error when running a ping from the instance. Dumping instance console..."
+			openstack console log show "$name" || true
+			echo "Done"
 			exit 1
 		fi
 	fi
@@ -265,4 +267,3 @@ else
 		read pause
 	fi
 fi
-


### PR DESCRIPTION
Start dumping the server console when a liveliness check fails. This should give us a little more context to work with when debugging things.

While we're here, we also increase the timeout in case it's the obvious issue of slow infra. One can hope, right?
