### PR TITLE
Include output of loadbalancer status

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -248,6 +248,8 @@ for driver in "${!drivers[@]}"; do
 		echo "Testing connectivity from the instance ${name}"
 		sleep 60
 		if ! ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no "$os_user"@"$fip_address" ping -c 1 1.1.1.1; then
+			echo "Error when running a ping from the instance. Dumping load balancer status..."
+			openstack loadbalancer status show "$lb_id"
 			echo "Error when running a ping from the instance. Dumping instance console..."
 			openstack console log show "$name" || true
 			echo "Done"


### PR DESCRIPTION
When the connectivity to the lb member fails using a FIP, we could also output the status of load-balancer to provide more information and facilitate debugging.