### PR TITLE
Make the liveliness periodic more robust

### DIFF
--- a/connectivity-test-cloud-init.yaml
+++ b/connectivity-test-cloud-init.yaml
@@ -1,0 +1,29 @@
+#cloud-config
+
+# Run a trivial http server which returns OK if it is able to connect to an
+# external web server.
+# N.B. This blocks, which means cloud-init will never complete. This is fine
+#      for this CI test.
+runcmd:
+- - /usr/bin/python
+  - -c
+  - |
+    from http.server import BaseHTTPRequestHandler
+    from http.server import HTTPServer
+    from urllib.request import urlopen
+
+    TEST_URL='https://www.google.com/'
+
+    class ConnectivityTest(BaseHTTPRequestHandler):
+        def do_GET(self):
+            try:
+                urlopen(TEST_URL, timeout=5)
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write('OK'.encode())
+            except Exception as ex:
+                self.send_response(500)
+                self.end_headers()
+                self.wfile.write(f'Unable to connect to {TEST_URL}: {ex}'.encode())
+
+    HTTPServer(('0.0.0.0', 80), ConnectivityTest).serve_forever()


### PR DESCRIPTION
The previous SSH test was prone to sporadic failures with a failure rate above 10% for the amphora driver in vh-mecha-central. The HTTP test has been reliable so far in testing.

The liveliness periodic invokes server.sh with `-u centos`, which both supplied the username to use when logging in via SSH and enabled the test. We no longer require a login username for the test so we add a new option `-l` which enables the test without taking an option. We retain the `-u` option for compatibility with the periodic. It can be removed after we have updated the periodic.