### PR TITLE
Relax regex for external subnets

### DIFF
--- a/stale.sh
+++ b/stale.sh
@@ -116,7 +116,7 @@ list_network() {
 		res="$(openstack network show -f json -c created_at -c name "$resource_id")"
 		creation_time="$(jq -r '.created_at' <<< "$res")"
 		name="$(jq -r '.name' <<< "$res")"
-		if [[ "$name" = *"hostonly"* ]] || [[ "$name" = *"external"* ]] || [[ "$name" = *"sahara-access"* ]] || [[ "$name" = *"mellanox"* ]] || [[ "$name" = *"intel"* ]] || [[ "$name" = *"public"* ]] || [[ "$name" = *"slaac"* ]]; then
+		if [[ "$name" = *"hostonly"* ]] || [[ "$name" = "external"* ]] || [[ "$name" = *"sahara-access"* ]] || [[ "$name" = *"mellanox"* ]] || [[ "$name" = *"intel"* ]] || [[ "$name" = *"public"* ]] || [[ "$name" = *"slaac"* ]]; then
 			continue
 		fi
 		printf '%s %s %s\n' "$resource_id" "$creation_time" "$name"
@@ -128,7 +128,7 @@ list_subnet() {
 		res="$(openstack subnet show -f json -c updated_at -c name "$resource_id")"
 		update_time="$(jq -r '.updated_at' <<< "$res")"
 		name="$(jq -r '.name' <<< "$res")"
-		if [[ "$name" = *"hostonly"* ]] || [[ "$name" = *"external"* ]] || [[ "$name" = *"public"* ]] || [[ "$name" = *"mellanox"* ]] || [[ "$name" = *"intel"* ]] || [[ "$name" = *"slaac"* ]]; then
+		if [[ "$name" = *"hostonly"* ]] || [[ "$name" = "external"* ]] || [[ "$name" = *"public"* ]] || [[ "$name" = *"mellanox"* ]] || [[ "$name" = *"intel"* ]] || [[ "$name" = *"slaac"* ]]; then
 			continue
 		fi
 		printf '%s %s %s\n' "$resource_id" "$update_time" "$name"


### PR DESCRIPTION
Now that we have subnets for externallb jobs, we need to relax the matching otherwise it fails to cleanup leaked resources by those jobs.