### PR TITLE
Remove potential stale ports before cleaning subnet

### DIFF
--- a/clean-ci-resources.sh
+++ b/clean-ci-resources.sh
@@ -120,6 +120,17 @@ for resource in 'loadbalancer' 'server' 'router' 'subnet' 'network' 'volume snap
 			echo "$r" | report $resource | xargs --verbose openstack $resource delete
 			done
 			;;
+		subnet)
+		  for r in $(./stale.sh -q "$resource"); do
+			network=$(openstack subnet show "$r" -c network_id -f value)
+			ports=$(openstack port list --network "$network" -f value -c id)
+			for port in $ports; do
+			  echo "$port" | report port | xargs --verbose openstack port delete
+			done
+			# shellcheck disable=SC2086
+			echo "$r" | report $resource | xargs --verbose openstack $resource delete
+			done
+			;;
 		*)
 			# shellcheck disable=SC2086
 			./stale.sh -q $resource | report $resource | xargs --verbose --no-run-if-empty openstack $resource delete


### PR DESCRIPTION
The proxy and az jobs create resources that may not be cleaned up upon job completion.

One such example was seen in
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-shiftstack-shiftstack-ci-main-periodic-4.13-e2e-openstack-az/1632828398344605696 where the leftover port on the proxy machine subnet caused the cleanup script to fail.