### PR TITLE
team_ssh_keys: Output to stdout

### DIFF
--- a/team_ssh_keys.sh
+++ b/team_ssh_keys.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# This script will generate a temporary file with all the ssh keys of the
-# approvers of a given team name in the OWNERS_ALIASES file of a given project.
-# The script will return the path of the temporary file.
+# This script returns the ssh keys of the approvers of a given team name in the
+# OWNERS_ALIASES file of a given project.
 # The script will return 1 if the script fails to curl the OWNER_ALIASES file
 # or if the yq command is not found.
 
@@ -23,11 +22,8 @@ if [ -z "$OWNER_ALIASES" ]; then
 fi
 
 # shellcheck disable=SC2016
-MEMBERS=$(echo "$OWNER_ALIASES" | yq --arg team_name "$TEAM_NAME" -r '.aliases[$team_name] | join(" ")')
+MEMBERS=$(yq --arg team_name "$TEAM_NAME" -r '.aliases[$team_name] | join(" ")' <<< "$OWNER_ALIASES")
 
-TMP_FILE=$(mktemp)
 for member in $MEMBERS; do
-    curl -s "https://github.com/$member.keys" >> "$TMP_FILE"
+    curl -s "https://github.com/$member.keys"
 done
-
-echo "$TMP_FILE"


### PR DESCRIPTION
This is a neat script, @EmilienM!

Here I propose to change the API and let the caller decide whether to redirect the output to a file.

In the case of an interactive invocation, the behaviour of the current version could be emulated with:

```bash
./team_ssh_keys.sh > $(mktemp | tee /dev/tty)
```