### PR TITLE
team_ssh_keys: Comment keys accounting for multiple entries

### DIFF
--- a/team_ssh_keys.sh
+++ b/team_ssh_keys.sh
@@ -26,5 +26,5 @@ MEMBERS=$(yq --arg team_name "$TEAM_NAME" -r '.aliases[$team_name] | join(" ")' 
 
 for member in $MEMBERS; do
     key=$(curl -s "https://github.com/$member.keys")
-    echo "$key $member"
+    printf '# %s\n%s\n\n' "$member" "$key"
 done


### PR DESCRIPTION
As Github allows including more than a key, switch to a style of commenting that is clear when there is more than one key per person.