### PR TITLE
Clean up INFRA_ID-worker server groups

### DIFF
--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -90,6 +90,7 @@ if [[ $FORCE == true ]]; then
     openstack security group delete "$INFRA_ID"-worker
 
     openstack server group delete "$INFRA_ID"-master
+    openstack server group delete "$INFRA_ID"-worker
 
     for c in $(openstack container list -f value); do
         echo "$c"


### PR DESCRIPTION
The worker server groups don't get deleted, which can cause deployment failues due to insufficient quota in OpenStack