### PR TITLE
Expose the networkType config in run_ocp

### DIFF
--- a/cluster_config.sh.example
+++ b/cluster_config.sh.example
@@ -10,6 +10,11 @@ export SSH_PUB_KEY="`cat $HOME/.ssh/id_rsa.pub`"
 export MASTER_COUNT=3
 export WORKER_COUNT=3
 
+# Select the CNI plugin to use in your OCP deployment
+# From OCP 4.15 <, use OpenShiftSDN
+# From OCP 4.15 >=, use KubernetesOVN
+export OPENSHIFT_NETWORKTYPE="OpenShiftSDN"
+
 ##############################################
 # The following settings are platform specific
 ##############################################

--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -101,7 +101,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.128.0/17
-  networkType: OpenShiftSDN
+  networkType: ${OPENSHIFT_NETWORKTYPE}
   serviceNetwork:
   - 172.30.0.0/16
 platform:


### PR DESCRIPTION
Make the networkType configurable depending on the OCP version to use.

For now, default to OpenShiftSDN.

OpenShiftSDN was deprecated in OCP 4.15 and will be removed in OCP 4.16