### PR TITLE
add dummy to jira names

### DIFF
--- a/cve-jira-processing/dup_cve.py
+++ b/cve-jira-processing/dup_cve.py
@@ -526,7 +526,7 @@ def create_verified_bug(
 
     Returns the bug key or a descriptive placeholder in dry-run mode.
     """
-    bug_summary = f"{cve_id} - {component} - {version}"
+    bug_summary = f"[DUMMY] {cve_id} - {component} - {version}"
 
     # Check cache first
     existing = cache.bugs_by_version.get(version)


### PR DESCRIPTION
seems like my trackers were picked up by the ART team automation, adding dummy to the names to make sure they don't come up in thier searches