### PR TITLE
Use image IDs instead of names in refresh_rhcos.sh swap

### DIFF
--- a/refresh_rhcos.sh
+++ b/refresh_rhcos.sh
@@ -102,11 +102,19 @@ new_image_id="$(openstack image create "${IMAGE_NAME}-new" --container-format ba
 
 echo "Replace old '$IMAGE_NAME' image with new one on '${OS_CLOUD}'"
 
-# Always only keep one backup of rhcos image
-openstack image delete "${IMAGE_NAME}-old" || true
+# Always only keep one backup of rhcos image (delete by ID to handle duplicates)
+for id in $(openstack image list --name "${IMAGE_NAME}-old" -f value -c ID 2>/dev/null); do
+    openstack image delete "$id" 2>/dev/null || true
+done
 
-# Then swap the images
-openstack image set --name "${IMAGE_NAME}-old" "$IMAGE_NAME" || true
+# Resolve current image by name to ID before renaming, so we don't
+# accidentally rename a different image uploaded by a concurrent job.
+current_id="$(openstack image list --name "$IMAGE_NAME" -f value -c ID 2>/dev/null | head -1)"
+
+# Then swap the images (by ID, not name)
+if [[ -n "$current_id" ]]; then
+    openstack image set --name "${IMAGE_NAME}-old" "$current_id" || true
+fi
 openstack image set --name "$IMAGE_NAME" "$new_image_id"
 
 echo Done


### PR DESCRIPTION
## Summary

The RHCOS image swap logic in `refresh_rhcos.sh` uses the image **name** directly in `openstack image set --name` and `openstack image delete` commands. This is fragile:

1. If another concurrent job uploaded a new image with the same name, line 109 renames the **wrong** image.
2. Deleting by name (`openstack image delete "${IMAGE_NAME}-old"`) when multiple images share the same name can have unpredictable results.

This patch switches to ID-based operations throughout, matching the approach already used by the `openstack-conf-rhcosimage` CI step in `openshift/release`:

- Delete old images by iterating over IDs from `openstack image list`
- Resolve the current image name to its ID **before** renaming
- Rename and promote using the resolved IDs

## Context

The `openstack-conf-rhcosimage` CI step was already rewritten to use this ID-based approach (see `openshift/release` step-registry). This change brings `refresh_rhcos.sh` into alignment, since both scripts serve the same purpose (RHCOS image lifecycle in Glance).

## Affected jobs

Reduces the rename race window for all Shiftstack CI jobs that share Glance images, particularly `periodic-ci-shiftstack-ci-release-4.22-e2e-openstack-ovn-parallel` which has been failing consistently due to image name drift.